### PR TITLE
Attempt submodule index.lock cleanup

### DIFF
--- a/src/fs-helper.ts
+++ b/src/fs-helper.ts
@@ -80,6 +80,13 @@ export function fileExistsSync(path: string): boolean {
   return false
 }
 
+/**
+ * Searches a given directory and returns a list of file paths giving all files in that directory.
+ * The file paths all begin at `dir`.
+ *
+ * @param dir The directory to search
+ * @returns A list of file paths,
+ */
 export async function readdirRecursive(dir: string): Promise<string[]> {
   const files = await fs.promises.readdir(dir);
   const result: string[] = [];

--- a/src/fs-helper.ts
+++ b/src/fs-helper.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as path from 'path'
 
 export function directoryExistsSync(path: string, required?: boolean): boolean {
   if (!path) {
@@ -77,4 +78,19 @@ export function fileExistsSync(path: string): boolean {
   }
 
   return false
+}
+
+export async function readdirRecursive(dir: string): Promise<string[]> {
+  const files = await fs.promises.readdir(dir);
+  const result: string[] = [];
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const stat = await fs.promises.stat(filePath);
+    if (stat.isDirectory()) {
+      result.push(...(await readdirRecursive(filePath)));
+    } else {
+      result.push(filePath);
+    }
+  }
+  return result;
 }

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -39,7 +39,7 @@ export async function prepareExistingDirectory(
     
     for (const file of await fsHelper.readdirRecursive(lockDir)) {
       if (file.endsWith('index.lock') || file.endsWith('shallow.lock')) {
-        lockPaths.push(path.join(lockDir, file))
+        lockPaths.push(file)
       }
     }
 
@@ -131,4 +131,3 @@ export async function prepareExistingDirectory(
     }
   }
 }
-

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -35,6 +35,14 @@ export async function prepareExistingDirectory(
       path.join(repositoryPath, '.git', 'index.lock'),
       path.join(repositoryPath, '.git', 'shallow.lock')
     ]
+    const lockDir = path.join(repositoryPath, '.git')
+    
+    for (const file of await fsHelper.readdirRecursive(lockDir)) {
+      if (file.endsWith('index.lock') || file.endsWith('shallow.lock')) {
+        lockPaths.push(path.join(lockDir, file))
+      }
+    }
+
     for (const lockPath of lockPaths) {
       try {
         await io.rmRF(lockPath)
@@ -123,3 +131,4 @@ export async function prepareExistingDirectory(
     }
   }
 }
+

--- a/src/git-directory-helper.ts
+++ b/src/git-directory-helper.ts
@@ -46,6 +46,7 @@ export async function prepareExistingDirectory(
     for (const lockPath of lockPaths) {
       try {
         await io.rmRF(lockPath)
+        core.info(`Deleted '${lockPath}'`)
       } catch (error) {
         core.debug(
           `Unable to delete '${lockPath}'. ${(error as any)?.message ?? error}`


### PR DESCRIPTION
index.lock files are not cleaned up from submodules when CI jobs are cancelled:
https://github.com/actions/checkout/issues/1153