### PR TITLE
Fix bug from recent change, submodule dir doesn't exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1072,11 +1072,13 @@ function prepareExistingDirectory(git, repositoryPath, repositoryUrl, clean, ref
                 path.join(repositoryPath, '.git', 'shallow.lock')
             ];
             // Handle submodules
-            const lockDir = path.join(repositoryPath, '.git', 'modules');
-            for (const file of yield fsHelper.readdirRecursive(lockDir)) {
-                if (file.endsWith('index.lock') || file.endsWith('shallow.lock')) {
-                    lockPaths.push(file);
-                }
+            const gitSubmoduleDir = path.join(repositoryPath, '.git', 'modules');
+            if (fsHelper.directoryExistsSync(gitSubmoduleDir)) {
+              for (const file of yield fsHelper.readdirRecursive(gitSubmoduleDir)) {
+                  if (file.endsWith('index.lock') || file.endsWith('shallow.lock')) {
+                      lockPaths.push(file);
+                  }
+              }
             }
             for (const lockPath of lockPaths) {
                 try {


### PR DESCRIPTION
To be merged to exa-v4.1.2 branch. Just didn't want to push directly without someone else looking first. 