### PR TITLE
Add submodules cleanup to checkout 'clean' 

### DIFF
--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -437,6 +437,16 @@ class GitCommandManager {
   }
 
   async tryClean(): Promise<boolean> {
+    // First deinitialize all submodules
+    await this.execGit(['submodule', 'deinit', '-f', '--all'], true)
+
+    // Remove submodule git directories
+    const gitModulesPath = path.join(this.workingDirectory, '.git', 'modules')
+    if (fs.existsSync(gitModulesPath)) {
+      await io.rmRF(gitModulesPath)
+    }
+
+    // Then do the normal clean
     const output = await this.execGit(['clean', '-ffdx'], true)
     return output.exitCode === 0
   }


### PR DESCRIPTION
Will still need to update all actions to actually use the 'clean' option but this will fix the issue from: https://exafunction.slack.com/archives/C03PRDTRQ3D/p1740035657076299

Not sure who else to add to this PR but feel free to add others for review. 