### PR TITLE
ci: update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,6 @@ inputs:
     description: The base URL for the GitHub instance that you are trying to clone from, will use environment defaults to fetch from the same instance that the workflow is running from unless specified. Example URLs are https://github.com or https://my-ghes-server.example.com
     required: false
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
## Summary
Update the `using` field in `action.yml` from `node20` to `node24` to resolve Node.js 20 deprecation warnings in downstream workflows (Exafunction/Exafunction).

Node.js 20 actions are deprecated and will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from runners on September 16th, 2026.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Review & Testing Checklist for Human
- [ ] Verify the checkout action works correctly with Node.js 24 runtime in a test workflow
- [ ] Confirm no regressions in submodule handling (custom patches in this fork)

### Notes
This is a one-line change to `action.yml` — the compiled `dist/index.js` does not need rebuilding since the JavaScript is Node-version agnostic. The `using` field only controls which Node runtime the GitHub Actions runner uses to execute the action.

Link to Devin session: https://staging.itsdev.in/sessions/c2c0d6bfd57a4840839ea2b1cdf593e6
Requested by: @pqn
<!-- devin-review-badge-staging-begin -->

---

<a href="https://staging.itsdev.in/review/exafunction/checkout/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
